### PR TITLE
Delete .npmignore and replace with "files"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-/.github
-/src
-/tsconfig.json
-/dist/test.*
-/dist/tsconfig.tsbuildinfo
-/test
-**.swp

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "The UI \"framework\", designed for Mixery",
   "type": "module",
   "main": "dist/index.js",
+  "files": [
+      "/dist/**/*.js",
+      "/dist/**/*.d.ts",
+      "!/dist/**/test*.*"
+  ],
   "scripts": {
     "test": "node dist/test.js"
   },


### PR DESCRIPTION
Just like with ``@mixery/state-machine``, this PR removes the troublesome ``.npmignore`` and replaces it with ``"files"`` array in ``package.json``, preventing secrets leaks in the future.